### PR TITLE
Fix missing commas in webpack config examples

### DIFF
--- a/0q_development_servers.md
+++ b/0q_development_servers.md
@@ -26,12 +26,11 @@ module.exports = {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'dist')
   },
-  devServer: {                                  // new line
-    static: {                                   // new line
-      directory: path.join(__dirname, "dist"),  // new line
-    },                                          // new line
-  }                                             // new line                                              
-
+  devServer: { // new line
+    static: { // new line
+      directory: path.join(__dirname, "dist"), // new line
+    }, // new line
+  }, // new line                               
   ...
 
 };

--- a/3b_managing_images_with_webpack.md
+++ b/3b_managing_images_with_webpack.md
@@ -25,7 +25,7 @@ Next, we need to configure webpack to use html-loader, as well as handle our ima
   test: /\.(gif|png|avif|jpe?g)$/,
   type: "asset/resource",
   generator: {
-    filename: "[name][ext]"
+    filename: "[name][ext]",
     publicPath: "assets/images/",
     outputPath: "assets/images/",
   },


### PR DESCRIPTION
## Description
In the current examples provided for setting up the dev server and setting up the asset modules, there are two missing commas that would lead to a syntax error if copied directly. This pull request fixes those issues, as well as slightly reformats the given snippet for setting up the dev server, removing excess spaces between the code and `new line` comments.

## Motivation and Context
If a student were to directly type or copy and paste the example provided, it would not work, as the missing commas would break the structure of the webpack config object. With webpack already being a tricky thing to setup, this eliminates one potential pain point.

## How Has This Been Tested?
I have directly copied the updated webpack config examples into a webpack project, and verified that my VS Code did not highlight any errors, as well as successfully built, ran, and linted the project with no errors as well.
