### PR TITLE
Add css link to example html

### DIFF
--- a/1b_address_book_user_interface.md
+++ b/1b_address_book_user_interface.md
@@ -34,6 +34,7 @@ Next let's fill in each section. First we'll add links to our `<head>` section:
     rel="stylesheet" 
     integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" 
     crossorigin="anonymous">
+  <link href="css/styles.css" rel="stylesheet" type="text/css">
   <script src="js/scripts.js"></script>
   <title>Address Book</title>
 </head>


### PR DESCRIPTION
## Description
Add a link to a `styles.css` file in the example HTML given for the address book.

## Motivation and Context
Fixes issue #12

The initial HTML doesn't contain a link to a custom CSS file, just bootstrap, and later down in the same lesson, it references adding a `.hidden` class style in the `styles.css` file. If the code were to be implemented verbatim, it wouldn't function as expected.  
 
## How Has This Been Tested?
Copied the example HTML with the added style sheet link, added some styles to verify the file was linked correctly. Tested in Brave and Chrome web browsers.
