### PR TITLE
Adjust directory name in testing example

### DIFF
--- a/2f_working_with_multiple_files.md
+++ b/2f_working_with_multiple_files.md
@@ -70,7 +70,7 @@ Because we've made a code update, we should verify that our tests still pass. An
 
 Because we are using a test-driven approach, our next step is to write a test. We'll start with a test for a `Rectangle` constructor:
 
-<div class="filename">src/rectangle.test.js</div>
+<div class="filename">__tests__/rectangle.test.js</div>
 
 ```js
 import Rectangle from '../src/js/rectangle.js';


### PR DESCRIPTION
## Description

Adjusts the directory given for the first test from `src` to the more accurate `__tests__`

## Motivation and Context

Addresses issue #20 

As stated in previous lessons, tests should go in the `__tests__` directory, so having an example that shows test files living in the `src` directory is contradictory to that.

## How Has This Been Tested?

There is really nothing to test, but I previewed the markdown in a markdown previewer to make sure it looked correct.