### PR TITLE
Update dotenv-webpack version

### DIFF
--- a/0h_managing_api_keys.md
+++ b/0h_managing_api_keys.md
@@ -49,7 +49,7 @@ We can add as many variables as we want (such as if we are working on a project 
 Next, we'll use a webpack plugin called `dotenv-webpack` to make our environmental variables available inside our application:
 
 ```shell
-$ npm install dotenv-webpack@2.0.0 --save-dev
+$ npm install dotenv-webpack@8.0.1 --save-dev
 ```
 
 Because it's a plugin, we need to first `require` it and then add it to the `plugins` array in `webpack.config.js`:


### PR DESCRIPTION
## Description
Changes the example install version of dotenv-webpack from 2.0.0 to 8.0.1

## Motivation and Context
After updating all previous dependencies to later versions compatible with webpack 5, the old version of dotenv no long works, and a later version needs to be used. 

## How Has This Been Tested?
Using a webpack template with all the dependencies we list in the lessons, I installed dotenv-webpack 8.0.1. After that I created a .env file, added a test .env variable with a sample string, and created an alert function to display the text in the browser. 
