### PR TITLE
add further clarification on creating .gitignore

### DIFF
--- a/0e_git_best_practices_and_adding_a_gitignore_file.md
+++ b/0e_git_best_practices_and_adding_a_gitignore_file.md
@@ -11,7 +11,13 @@ A `.gitignore` file lists all of the files that are _local_ to a project that Gi
 
 **In order for a `.gitignore` file to work correctly, it _must_ be committed _before_ we commit (by accident) any code we don't want in our Git history.**
 
-Let's create a `.gitignore` file now and list a few files and folders in it. When file(s) or folder(s) are listed in the `.gitignore`, then that directs Git to ignore them when you make commits.
+Let's create a `.gitignore` file in the root of our project and list a few files and folders in it. 
+
+```shell
+$ touch .gitignore
+```
+
+When file(s) or folder(s) are listed in the `.gitignore`, then that directs Git to ignore them when you make commits.
 
 <div class="filename">.gitignore</div>
 


### PR DESCRIPTION
Adds further clarification on creating the .gitignore file

## Description
Adds in a code block section instructing the reader to run the command `touch .gitignore` in the root of their project. Without running that command, there is no file to list any items in, and the subsequent command `git add .gitignore` will throw an error.

## Motivation and Context
Fixes issue #15 
As mentioned above, we never give an example on how to create a `.gitignore` file. This will add a bit more information on how to create that, as well as again reinforcing that it should be in the root of the project.

## How Has This Been Tested?
Viewed changed in a markdown preview to ensure there were no formatting errors
